### PR TITLE
[BUGFIX] Safari shows hidden <option> unless removed

### DIFF
--- a/Resources/Public/JavaScript/pxa_dealers.js
+++ b/Resources/Public/JavaScript/pxa_dealers.js
@@ -140,7 +140,7 @@
                                 var $this = $(this);
 
                                 if ($this.val() !== '0' && !PxaDealersMaps.FE.inList(visibleList, $this.val())) {
-                                    $this.hide();
+                                    $this.remove();
                                 }
                             });
                         }


### PR DESCRIPTION
Reg: Pxa Dealers Mode: Countries menu
All countries in the dropdown will show in Safari (desktop and ios) regardless if 'hidden' or not.
F.ex see https://stackoverflow.com/questions/6109085/disable-select-option-in-ios-safari