### PR TITLE
[FEATURE] Improve search results

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -51,7 +51,11 @@ plugin.tx_pxadealers {
     }
 
     search {
-      searchFields = name,zipcode,city,country.shortNameLocal,country.shortNameEn
+      searchFields = name,zipcode,city
+
+      # Search fields used if there are no results from searchFields. Prevents lots of results if country name is part
+      # of search phrase. These fields are typically fields with potentially broad search matches.
+      secondarySearchFields = country.shortNameLocal,country.shortNameEn
 
       # Search in radius by kilometers
       radius = 50


### PR DESCRIPTION
If no results are retrieved in radius search, a freetext search is performed instead.

If a freetext search fails, `search.secondarySearchFields` is used. This is preset to country name fields.