### PR TITLE
[BUGFIX] Fix JavaScript error on file concatenation

### DIFF
--- a/Resources/Private/Templates/Dealers/Map.html
+++ b/Resources/Private/Templates/Dealers/Map.html
@@ -8,7 +8,7 @@
         <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/Css/pxa_dealers.css" />
         <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/JavaScript/markerclusterer.js" library="1" />
         <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/JavaScript/isotope.pkgd.min.js" library="1" />
-        <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/JavaScript/pxa_dealers_plugin.js" library="1" />
+        <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/JavaScript/pxa_dealers_plugin.js" />
 
         <pxa:includeFile path="EXT:pxa_dealers/Resources/Public/JavaScript/pxa_dealers.js" />
 


### PR DESCRIPTION
The pxa_dealers_plugin.js file was loaded as a library, which led to load-order issues when the file was concatenated. The library flag has now been removed.