### PR TITLE
[BUGFIX] Fix map zoom function when choosing country

### DIFF
--- a/Resources/Public/JavaScript/pxa_dealers_plugin.js
+++ b/Resources/Public/JavaScript/pxa_dealers_plugin.js
@@ -406,18 +406,20 @@
             }
 
             $.each(hiddenItems, function () {
-                var $this = $(this),
-                    uid = $this.data('uid');
+                var uid = $(this).data('uid');
 
-                self.markers[uid].setVisible(false);
+                if(typeof self.markers[uid] !== 'undefined') {
+                    self.markers[uid].setVisible(false);
+                }
             });
 
 
             $.each(visibleItems, function () {
-                var $this = $(this),
-                    uid = $this.data('uid');
+                var uid = $(this).data('uid');
 
-                self.markers[uid].setVisible(true);
+                if(typeof self.markers[uid] !== 'undefined') {
+                    self.markers[uid].setVisible(true);
+                }
             });
 
             self.repaintMarkerClusterer();


### PR DESCRIPTION
A JavaScript error occured when choosing a country from the country menu and the map didn't zoom. This was caused by a missing test for available markers.