### PR TITLE
[FEATURE] Categories separated from dealers storage

### DIFF
--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -8,6 +8,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
 
@@ -41,7 +42,7 @@ class TcaUtility
      */
     public function getCategoriesPidRestriction(): string
     {
-        return $this->getForeignTableWhereRestriction('categoriesRestriction', 'sys_category');
+        return $this->getForeignTableWhereRestriction('sys_category');
     }
 
     /**
@@ -182,29 +183,18 @@ EOT;
     /**
      * Generate dynamic foreign table where
      *
-     * @param $restrictionField
      * @param $table
      * @return string
      */
-    protected function getForeignTableWhereRestriction(string $restrictionField, string $table): string
+    protected function getForeignTableWhereRestriction(string $table): string
     {
-        $restrictionValue = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(
-            'pxa_dealers',
-            $restrictionField
-        );
+        $categoryPid = GeneralUtility::makeInstance(ConfigurationManager::class)
+            ->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_FULL_TYPOSCRIPT)['plugin.']['tx_pxadealers.']['settings.']['categoryPid'];
 
-        switch ($restrictionValue) {
-            case 'current_pid':
-                $foreignTableWhere = ' AND ' . $table . '.pid=###CURRENT_PID### ';
-                break;
-            case 'siteroot':
-                $foreignTableWhere = ' AND ' . $table . '.pid=###SITEROOT### ';
-                break;
-            case 'page_tsconfig_idlist':
-                $foreignTableWhere = ' AND ' . $table . '.pid IN (###PAGE_TSCONFIG_IDLIST###) ';
-                break;
-            default:
-                $foreignTableWhere = '';
+        if ($categoryPid) {
+            $foreignTableWhere = ' AND ' . $table . '.pid='.$categoryPid.' ';
+        } else {
+            $foreignTableWhere = '';
         }
 
         return $foreignTableWhere;

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -30,6 +30,9 @@ plugin.tx_pxadealers {
             # cat=plugin.tx_pxadealers/pxadealers/050; type=int; label=Scroll fix for mobile view (width < 991)
             scrollFixMobile = 0
         }
+
+         # cat=plugin.tx_pxadealers/pxadealers/060; type=string; label=Categories PID storage
+         categoryPid =
 	}
 
     # customsubcategory=pxadealerslist=Dealers list settings

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -28,6 +28,9 @@ plugin.tx_pxadealers {
   }
 
   settings {
+
+    categoryPid = {$plugin.tx_pxadealers.settings.map.categoryPid}
+
     # Map settings
     map {
       stylesJSON =


### PR DESCRIPTION
Added new TypoScript parameter for plugin.tx_pxadelers.settings - categoryPid.
Now categories fetches from that storage to have a single entrypoint in case of many dealers storages 