### PR TITLE
[BUGFIX] Fix javascript type error

### DIFF
--- a/Resources/Public/JavaScript/pxa_dealers_search.js
+++ b/Resources/Public/JavaScript/pxa_dealers_search.js
@@ -110,11 +110,11 @@
                 if (this.status >= 200 && this.status < 400) {
                     var list = [];
 
-                    resp['db'].forEach(function (value, index) {
+                    Array.from(resp['db']).forEach(function (value, index) {
                         list.push({label: value, value: 'db::' + value});
                     });
 
-                    resp['google'].forEach(function (value, index) {
+                    Array.from(resp['google']).forEach(function (value, index) {
                         list.push({label: value, value: 'google::' + value});
                     });
 


### PR DESCRIPTION
Response data in `resp['db']` would sometimes appear as objects. This caused a type error. This is fixed by passing the data through `Array.from()`.